### PR TITLE
Add Intel Wi-Fi modules to modules.bad

### DIFF
--- a/PKGBUILD/steamfork-device-support/src/etc/sleep/modules.bad
+++ b/PKGBUILD/steamfork-device-support/src/etc/sleep/modules.bad
@@ -1,1 +1,2 @@
 mt7921e mt7921_common mt76_connac_lib mt76
+iwlmvm iwlwifi


### PR DESCRIPTION
Wi-Fi on the Air Pro (using AX210) was not reconnecting so this adds the Intel Wi-Fi modules to the list of modules that need to be removed and readded on sleep / resume