### PR TITLE
Ayaneo Air Plus: link fancontrol to Ayaneo Air

### DIFF
--- a/PKGBUILD/steamfork-device-support/src/etc/lib/steamfork_hwsupport/devicequirks/AYANEO-AIR-Plus/bin
+++ b/PKGBUILD/steamfork-device-support/src/etc/lib/steamfork_hwsupport/devicequirks/AYANEO-AIR-Plus/bin
@@ -1,0 +1,1 @@
+../AYANEO-AIR/bin/


### PR DESCRIPTION
Tested working on the 7320U model