### PR TITLE
Claw boot quirk

### DIFF
--- a/PKGBUILD/steamfork-device-support/src/etc/lib/steamfork_hwsupport/devicequirks/Micro-Star-International-Co.,-Ltd.-Claw-A1M/boot.d/001-hid_msi_claw
+++ b/PKGBUILD/steamfork-device-support/src/etc/lib/steamfork_hwsupport/devicequirks/Micro-Star-International-Co.,-Ltd.-Claw-A1M/boot.d/001-hid_msi_claw
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# TODO: fix this ugly temporary hack
+(sleep 5; echo "xinput" | sudo tee $(find /sys -name gamepad_mode_current 2> /dev/null)) &


### PR DESCRIPTION
Temporary hack until I figure out why hid-msi-claw isn't properly initializing