### PR TITLE
Fix display screen

### DIFF
--- a/PKGBUILD/steamfork-device-support/src/etc/lib/steamfork_hwsupport/devicequirks/AYANEO-FLIP-DS/hardware_quirks.sh
+++ b/PKGBUILD/steamfork-device-support/src/etc/lib/steamfork_hwsupport/devicequirks/AYANEO-FLIP-DS/hardware_quirks.sh
@@ -2,4 +2,4 @@
 export X11_ROTATION=left
 export GAMESCOPE_RES="-w 1280 -h 720"
 export GAMESCOPE_ADDITIONAL_OPTIONS="--force-orientation left"
-export GAMESCOPE_DISPLAY="eDP"
+export GAMESCOPE_DISPLAY="eDP-1,eDP-2"


### PR DESCRIPTION
https://github.com/SteamFork/bugtracker/issues/4

Set the priority of eDP-2 lower than eDP-1, so that gamescope will display on the top screen