### PR TITLE
Update InputPlumber patches

### DIFF
--- a/PKGBUILD/inputplumber/001-no-rootfs.patch
+++ b/PKGBUILD/inputplumber/001-no-rootfs.patch
@@ -10,12 +10,11 @@ index 1bfbb3c..296f386 100644
          PathBuf::from("/etc/inputplumber/devices.d"),
          get_base_path().join("devices"),
      ];
-@@ -48,7 +47,7 @@ pub fn get_capability_maps_paths() -> Vec<PathBuf> {
+@@ -48,7 +48,6 @@ pub fn get_capability_maps_paths() -> Vec<PathBuf> {
      let paths = vec![
          get_base_path().join("capability_maps"),
          PathBuf::from("/etc/inputplumber/capability_maps.d"),
 -        PathBuf::from("./rootfs/usr/share/inputplumber/capability_maps"),
-+        PathBuf::from("/usr/share/inputplumber/capability_maps"),
      ];
  
      paths

--- a/PKGBUILD/inputplumber/003-Update-mount_matrix.patch
+++ b/PKGBUILD/inputplumber/003-Update-mount_matrix.patch
@@ -1,0 +1,375 @@
+From c281e61ccf7476ee49190afc51dd18b23d2b5c04 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E3=83=B1=E3=83=83=E3=82=B8?= <uejjik@gmail.com>
+Date: Thu, 17 Oct 2024 18:05:00 -0500
+Subject: [PATCH 1/2] fix(mount_matrix): Swap roll and yaw axes
+
+Per discussion with @pastaq
+---
+ .../inputplumber/devices/50-ayaneo_air_plus_mendo.yaml |  5 +++--
+ .../usr/share/inputplumber/devices/50-ayaneo_next.yaml |  5 +++--
+ .../inputplumber/devices/50-ayn_loki_mini_pro.yaml     |  5 +++--
+ .../share/inputplumber/devices/50-ayn_loki_zero.yaml   |  4 ++--
+ .../usr/share/inputplumber/devices/50-legion_go.yaml   | 10 ++++++----
+ rootfs/usr/share/inputplumber/devices/50-msi_claw.yaml | 10 ++++++----
+ .../share/inputplumber/devices/50-orangepi_neo.yaml    |  5 +++--
+ 7 files changed, 26 insertions(+), 18 deletions(-)
+
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus_mendo.yaml b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus_mendo.yaml
+index 8cb61c5..d5e9264 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus_mendo.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus_mendo.yaml
+@@ -42,9 +42,10 @@ source_devices:
+     iio:
+       name: bmi323-imu
+       mount_matrix:
++        # TODO: Reverify on actual hardware
+         x: [0, -1, 0]
+-        y: [0, 0, 1]
+-        z: [-1, 0, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, 1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayaneo_next.yaml b/rootfs/usr/share/inputplumber/devices/50-ayaneo_next.yaml
+index a9f6978..56d29bb 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_next.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_next.yaml
+@@ -54,9 +54,10 @@ source_devices:
+     iio:
+       name: i2c-BMI0160:00
+       mount_matrix:
++        # TODO: Reverify on actual hardware
+         x: [0, -1, 0]
+-        y: [0, 0, -1]
+-        z: [1, 0, 0]
++        y: [1, 0, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml
+index c0a3783..f93346c 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml
+@@ -36,9 +36,10 @@ source_devices:
+     iio:
+       name: i2c-BMI0160:00
+       mount_matrix:
++        # TODO: Reverify on actual hardware
+         x: [1, 0, 0]
+-        y: [0, 0, -1]
+-        z: [0, 1, 0]
++        y: [0, 1, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml
+index 2cf91bf..8e18f10 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml
+@@ -37,8 +37,8 @@ source_devices:
+       name: i2c-BMI0160:00
+       mount_matrix:
+         x: [1, 0, 0]
+-        y: [0, 0, -1]
+-        z: [0, 1, 0]
++        y: [0, 1, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+index 1278124..16d8508 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+@@ -141,16 +141,18 @@ source_devices:
+ #    iio:
+ #      name: accel_3d
+ #      mount_matrix:
++#        # TODO: Reverify on actual hardware
+ #        x: [0, 1, 0]
+-#        y: [0, 0, -1]
+-#        z: [-1, 0, 0]
++#        y: [-1, 0, 0]
++#        z: [0, 0, -1]
+   - group: imu
+     iio:
+       name: gyro_3d
+       mount_matrix:
++        # TODO: Reverify on actual hardware
+         x: [0, 1, 0]
+-        y: [0, 0, -1]
+-        z: [-1, 0, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-msi_claw.yaml b/rootfs/usr/share/inputplumber/devices/50-msi_claw.yaml
+index 471da92..89c1735 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw.yaml
+@@ -40,16 +40,18 @@ source_devices:
+     iio:
+       name: accel_3d
+       mount_matrix:
++        # TODO: Reverify on actual hardware
+         x: [0, 1, 0]
+-        y: [0, 0, -1]
+-        z: [-1, 0, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, -1]
+   - group: imu
+     iio:
+       name: gyro_3d
+       mount_matrix:
++        # TODO: Reverify on actual hardware
+         x: [0, 1, 0]
+-        y: [0, 0, -1]
+-        z: [-1, 0, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml b/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
+index 4b289f5..0158b2b 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
+@@ -61,9 +61,10 @@ source_devices:
+     iio:
+       name: i2c-BMI0260:00
+       mount_matrix:
++        # TODO: Reverify on actual hardware
+         x: [1, 0, 0]
+-        y: [0, 0, -1]
+-        z: [0, -1, 0]
++        y: [0, -1, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+-- 
+2.43.0
+
+From d99eedaaad4fc86732d1904926907450ec7c7d54 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E3=83=B1=E3=83=83=E3=82=B8?= <uejjik@gmail.com>
+Date: Thu, 17 Oct 2024 17:21:14 -0500
+Subject: [PATCH 2/2] fix(mount_matrix): Update mount_matrix
+
+Update mount_matrix to match Steam Deck gyroscope output, per discussion with @pastaq
+
+Thanks to:
+@dansl and @cuongnphan for providing gyro data on Air 1S 7840U
+@aarron-lee for providing gyro data and testing on Win 4 6800U
+.bastardgoose on Discord for providing gyro data and testing on Ally X
+@fewtarius for providing gyro data on 2S, Flip KB and Loki Max
+@pastaq for providing gyro testing on Air, 2021 and Loki Max
+@winghugs for providing gyro testing on Air 1S 8840U
+
+Co-Authored-By: Dan Long <139961+dansl@users.noreply.github.com>
+Co-Authored-By: cuongnphan <65583536+cuongnphan@users.noreply.github.com>
+Co-Authored-By: Aarron Lee <lee.aarron.c@gmail.com>
+Co-Authored-By: fewtarius <88717793+fewtarius@users.noreply.github.com>
+Co-Authored-By: Derek J. Clark <derekjohn.clark@gmail.com>
+Co-Authored-By: Kin <22281362+winghugs@users.noreply.github.com>
+---
+ rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml    | 4 ++--
+ rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml | 4 ++--
+ rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml   | 8 +++++---
+ rootfs/usr/share/inputplumber/devices/50-ayaneo_air.yaml  | 4 ++--
+ .../usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml  | 6 ++++++
+ .../share/inputplumber/devices/50-ayaneo_air_plus.yaml    | 4 ++--
+ rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml | 8 +++++---
+ .../usr/share/inputplumber/devices/50-ayn_loki_max.yaml   | 4 ++--
+ rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml    | 6 ++++++
+ rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml    | 6 +++---
+ rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml  | 6 +++---
+ 11 files changed, 38 insertions(+), 22 deletions(-)
+
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
+index 5d4e261..a68cbe8 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
+@@ -45,8 +45,8 @@ source_devices:
+       name: i2c-BMI0160:00
+       mount_matrix:
+         x: [0, -1, 0]
+-        y: [0, 0, -1]
+-        z: [1, 0, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml
+index d7cf6e6..cd88fe3 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml
+@@ -49,8 +49,8 @@ source_devices:
+       name: i2c-10EC5280:00
+       mount_matrix:
+         x: [0, -1, 0]
+-        y: [0, 0, -1]
+-        z: [1, 0, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
+index 04f5ec3..c4b245f 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
+@@ -44,9 +44,11 @@ source_devices:
+     iio:
+       name: i2c-BMI0160:00
+       mount_matrix:
+-        x: [0, -1, 0]
+-        y: [0, 0, -1]
+-        z: [1, 0, 0]
++        # Calculated from observed gyro output
++        # TODO: Verify updated matrix on actual hardware
++        x: [0, 1, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, 1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air.yaml b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air.yaml
+index bad95e8..9ba17d0 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air.yaml
+@@ -40,8 +40,8 @@ source_devices:
+       name: i2c-BMI0160:00
+       mount_matrix:
+         x: [0, -1, 0]
+-        y: [0, 0, -1]
+-        z: [1, 0, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
+index 779ba5d..8a2598b 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
+@@ -43,6 +43,12 @@ source_devices:
+   - group: imu
+     iio:
+       name: i2c-BMI0160:00
++      mount_matrix:
++        # Tested on Air 1S 8840U
++        # TODO: Verify on 7840U
++        x: [0, -1, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml
+index 3c15719..4b5a02b 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml
+@@ -52,8 +52,8 @@ source_devices:
+       name: bmi323-imu
+       mount_matrix:
+         x: [0, -1, 0]
+-        y: [0, 0, 1]
+-        z: [-1, 0, 0]
++        y: [1, 0, 0]
++        z: [0, 0, 1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml b/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
+index 2882d9f..babfd2f 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
+@@ -44,9 +44,11 @@ source_devices:
+     iio:
+       name: i2c-BMI0160:00
+       mount_matrix:
+-        x: [0, -1, 0]
+-        y: [0, 0, -1]
+-        z: [1, 0, 0]
++        # Calculated from observed gyro output
++        # TODO: Verify updated matrix on actual hardware
++        x: [0, 1, 0]
++        y: [-1, 0, 0]
++        z: [0, 0, 1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml
+index fed2735..01bfb19 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml
+@@ -37,8 +37,8 @@ source_devices:
+       name: i2c-BMI0160:00
+       mount_matrix:
+         x: [1, 0, 0]
+-        y: [0, 0, -1]
+-        z: [0, 1, 0]
++        y: [0, -1, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml b/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
+index 866dc43..20cf87c 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
+@@ -35,6 +35,12 @@ source_devices:
+   - group: imu
+     iio:
+       name: i2c-BMI0160:00
++      mount_matrix:
++        # Tested on 6800U
++        # TODO: Verify on other models
++        x: [-1, 0, 0]
++        y: [0, -1, 0]
++        z: [0, 0, 1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml b/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml
+index d3106ab..8e9fbd6 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml
+@@ -50,9 +50,9 @@ source_devices:
+     iio:
+       name: bmi323-imu
+       mount_matrix:
+-        x: [-1, 0, 0]
+-        y: [0, 0, -1]
+-        z: [0, 1, 0]
++        x: [1, 0, 0]
++        y: [0, -1, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+diff --git a/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml b/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
+index a80d292..8f5b2f7 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
+@@ -49,9 +49,9 @@ source_devices:
+     iio:
+       name: bmi323-imu
+       mount_matrix:
+-        x: [-1, 0, 0]
+-        y: [0, 0, -1]
+-        z: [0, 1, 0]
++        x: [1, 0, 0]
++        y: [0, -1, 0]
++        z: [0, 0, -1]
+ 
+ # Optional configuration for the composite device
+ options:
+-- 
+2.43.0
+

--- a/PKGBUILD/inputplumber/PKGBUILD
+++ b/PKGBUILD/inputplumber/PKGBUILD
@@ -15,13 +15,15 @@ conflicts=('inputplumber-bin')
 source=("${_pkgbase}::git+https://github.com/ShadowBlip/${_pkgbase}.git"
 	001-no-rootfs.patch
 	002-enable-gyro-air_zero.patch
+	003-Update-mount_matrix.patch
 )
 
 options=(!lto)
 
 sha256sums=('SKIP'
-	'f7a36eda6757af5d62a7a948615954df8654ba9680b2987df24ba20d97b17e0d'  # 001-no-rootfs.patch
+	'55d15e63e2229e239b51823ba1a92522cba4a04e424c8515c210c102b4b6a88c'  # 001-no-rootfs.patch
 	'2b7c306d0846e21d3e6a181fba62db04edaabc804bcddde4ee158d902c8ef27f'  # 002-enable-gyro-air_zero.patch
+	'0cc586e16d6003f5872244c13d6e1b0345773a50f44d6de71778be3fda0adfec'  # 003-Update-mount_matrix.patch
 )
 
 prepare() {

--- a/PKGBUILD/inputplumber/PKGBUILD
+++ b/PKGBUILD/inputplumber/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=inputplumber
 _pkgbase=inputplumber
 pkgver=0.36.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Open source input router and remapper daemon for Linux"
 arch=('x86_64')
 url="https://github.com/ShadowBlip/InputPlumber"


### PR DESCRIPTION
No need to specify `/usr/share/inputplumber/capability_maps` as it is already included by `get_base_path().join("capability_maps")`.

Also includes current patch set for https://github.com/ShadowBlip/InputPlumber/pull/220