### PR TITLE
Display scripts overhaul

### DIFF
--- a/PKGBUILD/steamfork-device-support/PKGBUILD
+++ b/PKGBUILD/steamfork-device-support/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Fewtarius
 
 pkgname=steamfork-device-support
-pkgver=2024.12.06
-pkgrel=3
+pkgver=2024.12.17
+pkgrel=1
 pkgdesc='Hardware support provider for PC handhelds.'
 arch=('any')
 url='http://www.steamfork.org'

--- a/PKGBUILD/steamfork-device-support/src/etc/gamescope/scripts/displays/AYA-AYANEOFHD.lua
+++ b/PKGBUILD/steamfork-device-support/src/etc/gamescope/scripts/displays/AYA-AYANEOFHD.lua
@@ -7,58 +7,41 @@ local panel_models = {
   { vendor = "AYA", model = "AYANEOFHD" },
 }
 
-local panel_colorimetry = {
-  r = { x = 0.6503, y = 0.3388 },
-  g = { x = 0.3242, y = 0.6132 },
-  b = { x = 0.1572, y = 0.0488 },
-  w = { x = 0.3134, y = 0.3291 }
-}
-
-local panel_resolutions = {
-  { width = 1080, height = 1920,
-    hfront = 90, hsync = 18, hback = 72,
-    vfront = 14,  vsync = 2, vback = 8 },
-}
-
 local panel_refresh_rates = { 60, 120 }
-
-local panel_hdr = {
-  supported = false,
-  force_enabled = false,
-  eotf = gamescope.eotf.gamma22,
-  max_content_light_level = 500,
-  max_frame_average_luminance = 500,
-  min_content_light_level = 0.5
-}
 
 
 gamescope.config.known_displays[panel_id] = {
   pretty_name = panel_name,
-  dynamic_refresh_rates = panel_refresh_rates,
-  hdr = panel_hdr,
-  colorimetry = panel_colorimetry,
+
+  -- These tables are optional
+  colorimetry = (panel_colorimetry ~= nil) and panel_colorimetry,
+  dynamic_refresh_rates = (panel_refresh_rates ~= nil) and panel_refresh_rates,
+  hdr = (panel_hdr ~= nil) and panel_hdr,
 
   dynamic_modegen = function(base_mode, refresh)
     local mode = base_mode
-    local found_res = false
-    local set_res = panel_resolutions[1]
-    debug("["..panel_id.."] Generating mode "..mode.hdisplay.."x"..mode.vdisplay.."@"..refresh.."Hz")
+    debug("["..panel_id.."] Switching mode to "..mode.hdisplay.."x"..mode.vdisplay.."@"..refresh.."Hz")
 
-    for i, res in ipairs(panel_resolutions) do
-      if res.width == mode.hdisplay and res.height == mode.vdisplay then
-        found_res = true
-        set_res = res
-        break
+    -- Override blanking intervals if defined
+    if panel_resolutions ~= nil then
+      for i, res in ipairs(panel_resolutions) do
+        if res.width == mode.hdisplay and res.height == mode.vdisplay then
+
+          if res.hfp ~= nil and res.hsync ~= nil and res.hbp ~= nil then
+            gamescope.modegen.set_h_timings(mode, set_res.hfp, set_res.hsync, set_res.hbp)
+            debug("["..panel_id.."] Overriding horizontal blanking interval")
+          end
+
+          if res.vfp ~= nil and res.vsync ~= nil and res.vbp ~= nil then
+            gamescope.modegen.set_v_timings(mode, set_res.vfp, set_res.vsync, set_res.vbp)
+            debug("["..panel_id.."] Overriding vertical blanking interval")
+          end
+
+          -- No need to iterate anymore
+          break
+        end
       end
     end
-
-    if not found_res then
-      debug("["..panel_id.."] Generating mode failed.  Setting default resolution of "..set_res.width.."x"..set_res.height)
-      gamescope.modegen.set_resolution(mode, set_res.width, set_res.height)
-    end
-
-    gamescope.modegen.set_h_timings(mode, set_res.hfront, set_res.hsync, set_res.hback)
-    gamescope.modegen.set_v_timings(mode, set_res.vfront, set_res.vsync, set_res.vback)
 
     mode.clock = gamescope.modegen.calc_max_clock(mode, refresh)
     mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)

--- a/PKGBUILD/steamfork-device-support/src/etc/gamescope/scripts/displays/AYA-AYANEOHD.lua
+++ b/PKGBUILD/steamfork-device-support/src/etc/gamescope/scripts/displays/AYA-AYANEOHD.lua
@@ -1,6 +1,6 @@
 -- Ayaneo Air Plus
--- Ayaneo Slide
--- Antec Core HS
+-- Ayaneo Slide (?)
+-- Antec Core HS (?)
 
 local panel_id = "ayaneo_hd_lcd"
 local panel_name = "Ayaneo HD LCD Panel"
@@ -9,73 +9,44 @@ local panel_models = {
   { vendor = "AYA", model = "AYANEOHD" },
 }
 
-local panel_colorimetry = {
-  r = { x = 0.6484, y = 0.3388 },
-  g = { x = 0.2822, y = 0.6025 },
-  b = { x = 0.1425, y = 0.0703 },
-  w = { x = 0.3134, y = 0.3291 }
-}
-
-local panel_resolutions = {
-  { width = 1080, height = 1920,
-    hfront = 116, hsync = 4, hback = 34,
-    vfront = 20, vsync = 2, vback = 6 },
-  { width = 600, height = 1066,
-    hfront = 64, hsync = 8, hback = 88,
-    vfront = 20, vsync = 8, vback = 12 },
-  { width = 768, height = 1024,
-    hfront = 64, hsync = 8, hback = 88,
-    vfront = 20, vsync = 8, vback = 12 },
-  { width = 600, height = 800,
-    hfront = 64, hsync = 8, hback = 88,
-    vfront = 20, vsync = 8, vback = 12 },
-  { width = 720, height = 1280,
-    hfront = 68, hsync = 8, hback = 88,
-    vfront = 12, vsync = 4, vback = 8 },
-}
-
 local panel_refresh_rates = {}
 for hz = 45, 60 do
   table.insert(panel_refresh_rates, hz)
 end
 
-local panel_hdr = {
-  supported = false,
-  force_enabled = false,
-  eotf = gamescope.eotf.gamma22,
-  max_content_light_level = 500,
-  max_frame_average_luminance = 500,
-  min_content_light_level = 0.5
-}
-
 
 gamescope.config.known_displays[panel_id] = {
   pretty_name = panel_name,
-  dynamic_refresh_rates = panel_refresh_rates,
-  hdr = panel_hdr,
-  colorimetry = panel_colorimetry,
+
+  -- These tables are optional
+  colorimetry = (panel_colorimetry ~= nil) and panel_colorimetry,
+  dynamic_refresh_rates = (panel_refresh_rates ~= nil) and panel_refresh_rates,
+  hdr = (panel_hdr ~= nil) and panel_hdr,
 
   dynamic_modegen = function(base_mode, refresh)
     local mode = base_mode
-    local found_res = false
-    local set_res = panel_resolutions[1]
-    debug("["..panel_id.."] Generating mode "..mode.hdisplay.."x"..mode.vdisplay.."@"..refresh.."Hz")
+    debug("["..panel_id.."] Switching mode to "..mode.hdisplay.."x"..mode.vdisplay.."@"..refresh.."Hz")
 
-    for i, res in ipairs(panel_resolutions) do
-      if res.width == mode.hdisplay and res.height == mode.vdisplay then
-        found_res = true
-        set_res = res
-        break
+    -- Override blanking intervals if defined
+    if panel_resolutions ~= nil then
+      for i, res in ipairs(panel_resolutions) do
+        if res.width == mode.hdisplay and res.height == mode.vdisplay then
+
+          if res.hfp ~= nil and res.hsync ~= nil and res.hbp ~= nil then
+            gamescope.modegen.set_h_timings(mode, set_res.hfp, set_res.hsync, set_res.hbp)
+            debug("["..panel_id.."] Overriding horizontal blanking interval")
+          end
+
+          if res.vfp ~= nil and res.vsync ~= nil and res.vbp ~= nil then
+            gamescope.modegen.set_v_timings(mode, set_res.vfp, set_res.vsync, set_res.vbp)
+            debug("["..panel_id.."] Overriding vertical blanking interval")
+          end
+
+          -- No need to iterate anymore
+          break
+        end
       end
     end
-
-    if not found_res then
-      debug("["..panel_id.."] Generating mode failed.  Setting default resolution of "..set_res.width.."x"..set_res.height)
-      gamescope.modegen.set_resolution(mode, set_res.width, set_res.height)
-    end
-
-    gamescope.modegen.set_h_timings(mode, set_res.hfront, set_res.hsync, set_res.hback)
-    gamescope.modegen.set_v_timings(mode, set_res.vfront, set_res.vsync, set_res.vback)
 
     mode.clock = gamescope.modegen.calc_max_clock(mode, refresh)
     mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)

--- a/PKGBUILD/steamfork-device-support/src/etc/gamescope/scripts/displays/AYA-AYANEOWUXGA.lua
+++ b/PKGBUILD/steamfork-device-support/src/etc/gamescope/scripts/displays/AYA-AYANEOWUXGA.lua
@@ -8,79 +8,44 @@ local panel_models = {
   { vendor = "AYA", model = "AYANEOWUXGA" },
 }
 
-local panel_colorimetry = {
-  r = { x = 0.6503, y = 0.3388 },
-  g = { x = 0.3242, y = 0.6132 },
-  b = { x = 0.1572, y = 0.0488 },
-  w = { x = 0.3134, y = 0.3291 }
-}
-
-local panel_resolutions = {
-  { width = 1200, height = 1920,
-    hfront = 64, hsync = 24, hback = 32,
-    vfront = 60, vsync = 8, vback = 32 },
-  { width = 1080, height = 1920,
-    hfront = 40, hsync = 8, hback = 120,
-    vfront = 8, vsync = 16, vback = 44 },
-  { width = 720, height = 1152,
-    hfront = 64, hsync = 8, hback = 88,
-    vfront = 8, vsync = 20, vback = 12 },
-  { width = 800, height = 1280,
-    hfront = 32, hsync = 10, hback = 118,
-    vfront = 10, vsync = 16, vback = 20 },
-  { width = 720, height = 1280,
-    hfront = 64, hsync = 8, hback = 68,
-    vfront = 10, vsync = 16, vback = 14 },
-  { width = 768, height = 1024,
-    hfront = 48, hsync = 10, hback = 82,
-    vfront = 10, vsync = 24, vback = 22 },
-  { width = 600, height = 960,
-    hfront = 68, hsync = 8, hback = 88,
-    vfront = 12, vsync = 4, vback = 8 },
-}
-
 local panel_refresh_rates = {}
 for hz = 46, 60 do
   table.insert(panel_refresh_rates, hz)
 end
 
-local panel_hdr = {
-  supported = false,
-  force_enabled = false,
-  eotf = gamescope.eotf.gamma22,
-  max_content_light_level = 500,
-  max_frame_average_luminance = 500,
-  min_content_light_level = 0.5
-}
-
 
 gamescope.config.known_displays[panel_id] = {
   pretty_name = panel_name,
-  dynamic_refresh_rates = panel_refresh_rates,
-  hdr = panel_hdr,
-  colorimetry = panel_colorimetry,
+
+  -- These tables are optional
+  colorimetry = (panel_colorimetry ~= nil) and panel_colorimetry,
+  dynamic_refresh_rates = (panel_refresh_rates ~= nil) and panel_refresh_rates,
+  hdr = (panel_hdr ~= nil) and panel_hdr,
 
   dynamic_modegen = function(base_mode, refresh)
     local mode = base_mode
-    local found_res = false
-    local set_res = panel_resolutions[1]
-    debug("["..panel_id.."] Generating mode "..mode.hdisplay.."x"..mode.vdisplay.."@"..refresh.."Hz")
+    debug("["..panel_id.."] Switching mode to "..mode.hdisplay.."x"..mode.vdisplay.."@"..refresh.."Hz")
 
-    for i, res in ipairs(panel_resolutions) do
-      if res.width == mode.hdisplay and res.height == mode.vdisplay then
-        found_res = true
-        set_res = res
-        break
+    -- Override blanking intervals if defined
+    if panel_resolutions ~= nil then
+      for i, res in ipairs(panel_resolutions) do
+        if res.width == mode.hdisplay and res.height == mode.vdisplay then
+
+          if res.hfp ~= nil and res.hsync ~= nil and res.hbp ~= nil then
+            gamescope.modegen.set_h_timings(mode, set_res.hfp, set_res.hsync, set_res.hbp)
+            debug("["..panel_id.."] Overriding horizontal blanking interval")
+          end
+
+          if res.vfp ~= nil and res.vsync ~= nil and res.vbp ~= nil then
+            gamescope.modegen.set_v_timings(mode, set_res.vfp, set_res.vsync, set_res.vbp)
+            debug("["..panel_id.."] Overriding vertical blanking interval")
+          end
+
+          -- No need to iterate anymore
+          break
+        end
       end
     end
-
-    if not found_res then
-      debug("["..panel_id.."] Generating mode failed.  Setting default resolution of "..set_res.width.."x"..set_res.height)
-      gamescope.modegen.set_resolution(mode, set_res.width, set_res.height)
-    end
-
-    gamescope.modegen.set_h_timings(mode, set_res.hfront, set_res.hsync, set_res.hback)
-    gamescope.modegen.set_v_timings(mode, set_res.vfront, set_res.vsync, set_res.vback)
 
     mode.clock = gamescope.modegen.calc_max_clock(mode, refresh)
     mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)

--- a/PKGBUILD/steamfork-device-support/src/etc/gamescope/scripts/displays/AYN-LK-GOLSPV58.lua
+++ b/PKGBUILD/steamfork-device-support/src/etc/gamescope/scripts/displays/AYN-LK-GOLSPV58.lua
@@ -9,80 +9,44 @@ local panel_models = {
   { vendor = "AYN", model = "LK-GOLDSPV58" },
 }
 
-local panel_colorimetry = {
-  r = { x = 0.0000, y = 0.0000 },
-  g = { x = 0.0000, y = 0.0000 },
-  b = { x = 0.0000, y = 0.0000 },
-  w = { x = 0.0000, y = 0.0000 }
-}
-
-local panel_resolutions = {
-  { width = 1080, height = 1920,
-    hfront = 25, hsync = 10, hback = 15,
-    vfront = 3, vsync = 16, vback = 20 },
-  { width = 810, height = 1440,
-    hfront = 144, hsync = 80, hback = 64,
-    vfront = 40, vsync = 10, vback = 3 },
-  { width = 768, height = 1024,
-    hfront = 48, hsync = 10, hback = 82,
-    vfront = 10, vsync = 24, vback = 22 },
-  { width = 720, height = 1280,
-    hfront = 128, hsync = 72, hback = 56,
-    vfront = 34, vsync = 10, vback = 3 },
-  { width = 648, height = 1152,
-    hfront = 112, hsync = 64, hback = 48,
-    vfront = 30, vsync = 10, vback = 3 },
-  { width = 600, height = 800,
-    hfront = 88, hsync = 56, hback = 31,
-    vfront = 18, vsync = 10, vback = 3 },
-  { width = 768, height = 1366,
-    hfront = 136, hsync = 80, hback = 56,
-    vfront = 37, vsync = 10, vback = 3 },
-}
-
-
 local panel_refresh_rates = {}
 for hz = 31, 60 do
   table.insert(panel_refresh_rates, hz)
 end
 
-local panel_hdr = {
-  supported = false,
-  force_enabled = false,
-  eotf = gamescope.eotf.gamma22,
-  max_content_light_level = 500,
-  max_frame_average_luminance = 500,
-  min_content_light_level = 0.5
-}
-
 
 gamescope.config.known_displays[panel_id] = {
   pretty_name = panel_name,
-  dynamic_refresh_rates = panel_refresh_rates,
-  hdr = panel_hdr,
-  --colorimetry = panel_colorimetry,
+
+  -- These tables are optional
+  colorimetry = (panel_colorimetry ~= nil) and panel_colorimetry,
+  dynamic_refresh_rates = (panel_refresh_rates ~= nil) and panel_refresh_rates,
+  hdr = (panel_hdr ~= nil) and panel_hdr,
 
   dynamic_modegen = function(base_mode, refresh)
     local mode = base_mode
-    local found_res = false
-    local set_res = panel_resolutions[1]
-    debug("["..panel_id.."] Generating mode "..mode.hdisplay.."x"..mode.vdisplay.."@"..refresh.."Hz")
+    debug("["..panel_id.."] Switching mode to "..mode.hdisplay.."x"..mode.vdisplay.."@"..refresh.."Hz")
 
-    for i, res in ipairs(panel_resolutions) do
-      if res.width == mode.hdisplay and res.height == mode.vdisplay then
-        found_res = true
-        set_res = res
-        break
+    -- Override blanking intervals if defined
+    if panel_resolutions ~= nil then
+      for i, res in ipairs(panel_resolutions) do
+        if res.width == mode.hdisplay and res.height == mode.vdisplay then
+
+          if res.hfp ~= nil and res.hsync ~= nil and res.hbp ~= nil then
+            gamescope.modegen.set_h_timings(mode, set_res.hfp, set_res.hsync, set_res.hbp)
+            debug("["..panel_id.."] Overriding horizontal blanking interval")
+          end
+
+          if res.vfp ~= nil and res.vsync ~= nil and res.vbp ~= nil then
+            gamescope.modegen.set_v_timings(mode, set_res.vfp, set_res.vsync, set_res.vbp)
+            debug("["..panel_id.."] Overriding vertical blanking interval")
+          end
+
+          -- No need to iterate anymore
+          break
+        end
       end
     end
-
-    if not found_res then
-      debug("["..panel_id.."] Generating mode failed.  Setting default resolution of "..set_res.width.."x"..set_res.height)
-      gamescope.modegen.set_resolution(mode, set_res.width, set_res.height)
-    end
-
-    gamescope.modegen.set_h_timings(mode, set_res.hfront, set_res.hsync, set_res.hback)
-    gamescope.modegen.set_v_timings(mode, set_res.vfront, set_res.vsync, set_res.vback)
 
     mode.clock = gamescope.modegen.calc_max_clock(mode, refresh)
     mode.vrefresh = gamescope.modegen.calc_vrefresh(mode)


### PR DESCRIPTION
This is the beginning of an overhaul of the gamescope display lua scripts to make configuration and creation of new panel scripts easier.

Step 1: It is no longer necessary to specify horizontal and vertical blanking intervals unless you wish to override the EDID.