### PR TITLE
Revbump gamescope

### DIFF
--- a/PKGBUILD/gamescope/PKGBUILD
+++ b/PKGBUILD/gamescope/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Pierre-Loup A. Griffais <pgriffais@valvesoftware.com>
 
 pkgname=gamescope
-_srctag=3.15.14
+_srctag=3.15.15
 pkgver=${_srctag//-/.}.SteamFork
 pkgrel=5
 pkgdesc="gaming shell based on Xwayland, powered by Vulkan and DRM"


### PR DESCRIPTION
Updated to 3.15.15

```
layer: Move strict -> ensure

Matches Mesa behaviour, I'm a bit scared of breaking other broken games with this sweeping change.
```