### PR TITLE
Drop mkdir -p /.home/steamos from steamfork-create-overlays

### DIFF
--- a/PKGBUILD/steamfork-customizations/src/usr/bin/steamfork-create-overlays
+++ b/PKGBUILD/steamfork-customizations/src/usr/bin/steamfork-create-overlays
@@ -3,7 +3,6 @@ if [[ -d "/var/overlays/etc/" ]]; then
     echo "Overlays good, continue booting" | systemd-cat -t steamfork-create-overlays -p info
 else
     echo "No RW overlays, create them" | systemd-cat -t steamfork-create-overlays -p warning
-    mkdir -p /home/.steamos/
     mkdir -p /home/.steamos/offload/opt
     mkdir -p /home/.steamos/offload/root
     mkdir -p /home/.steamos/offload/srv


### PR DESCRIPTION
Running mkdir -p is supposed to create /home/.steamos even without the first line.
It's not all that useful change but I find it a bit redundant. Feel free to deny the merge if you want anyway :)