### PR TITLE
Add depth=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ex. `steamfork-installer --drive /dev/sda --username builder --password SteamFor
 
 ### Building Images
 Log in as your user and perform the following steps to configure the OS for building:
-1. Clone the SteamFork distribution repository: `git clone https://github.com/SteamFork/distribution.git`
+1. Clone the SteamFork distribution repository: `git clone https://github.com/SteamFork/distribution.git --depth=1`
 2. Build SteamFork: `cd distribution && make image rel`
 
 Optional:


### PR DESCRIPTION
Using --depth=1 downloads only the latest version of the folder instead of the whole git history: this way it is faster to download it (except for the fact you will lose the git history but it is useful only to those who actually git commit it)