### PR TITLE
Corrects an issue with panel power saving / adaptive backlight on kernels newer than 6.12.4. 

### DIFF
--- a/PKGBUILD/linux/0052-adaptive-backlight-management.patch
+++ b/PKGBUILD/linux/0052-adaptive-backlight-management.patch
@@ -1,0 +1,17 @@
+diff -rupN linux-6.12.7.orig/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c linux-6.12.7/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c
+--- linux-6.12.7.orig/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c	2024-12-27 13:02:20.000000000 +0000
++++ linux-6.12.7/drivers/gpu/drm/amd/amdgpu/amdgpu_device.c	2024-12-28 21:12:33.588022940 +0000
+@@ -3721,8 +3721,12 @@ static int amdgpu_device_ip_resume_phase
+ 			continue;
+ 		if (adev->ip_blocks[i].version->type == AMD_IP_BLOCK_TYPE_DCE) {
+ 			r = adev->ip_blocks[i].version->funcs->resume(adev);
+-			if (r)
++			if (r) {
++				DRM_ERROR("resume of IP block <%s> failed %d\n",
++					adev->ip_blocks[i].version->funcs->name, r);
+ 				return r;
++			}
++			adev->ip_blocks[i].status.hw = true;
+ 		}
+ 	}
+ 

--- a/PKGBUILD/linux/PKGBUILD
+++ b/PKGBUILD/linux/PKGBUILD
@@ -6,7 +6,7 @@
 #             Mikael Eriksson <mikael_eriksson@miffe.org>
 
 pkgbase=linux
-pkgver=6.12.6
+pkgver=6.12.7
 pkgrel=2
 pkgdesc="Linux Stable"
 arch=(x86_64)
@@ -65,6 +65,7 @@ source=(
   0040-vcs-amdgpu-quirks.patch
   0041-air-amdgpu-quirks.patch
   0051-drm-amd-display-let-update_planes_and_stream_state-d.patch
+  0052-adaptive-backlight-management.patch
   0060-asus-patch-series.patch
   0070-lexar-nvme-broken-msi.patch
   0099-add-external-device-drivers.patch
@@ -95,6 +96,7 @@ sha256sums=('SKIP'
 '93087d9449f994dca23c1d5a32919204d31afecc63950d74a2ea41aaa1e3a9ec' # 0040-vcs-amdgpu-quirks.patch
 'ab8a6dccf67cee7d924ee2e3d4690285d404bcb9bab70eced09b05fa2853b288' # 0041-air-amdgpu-quirks.patch
 '7c7df8d4427c807e2cea0f1e147efcdfb1e7c1c5271823cc6bb49f10b1846d19' # 0051-drm-amd-display-let-update_planes_and_stream_state-d.patch
+'7010f004fda33d83ae4c34db23da047da1677fabaa6d1c688be58b0230fd8ed0' # 0052-adaptive-backlight-management.patch
 'ee4bda8ed96baa79475d98720e85c67b6a8dcf82a98c41d9860883c407f9a6fb' # 0060-asus-patch-series.patch
 'b048068eeee69bf0f600d2ea390c8f681f9708776ff45a4b871e1e51136af33a' # 0070-lexar-nvme-broken-msi.patch
 '3b1dabc168e4884c6586720538014d6ef8955a0b783d6436dd4937af6622ee42' # 0099-add-external-device-drivers.patch


### PR DESCRIPTION
Thanks to @scardracs for pointing us to https://gitlab.freedesktop.org/drm/amd/-/issues/3853#note_2714815