### PR TITLE
Apply Gamescope Fix getting Vulkan DRM formats if backend doesn't use modifiers patch, thanks to @bcomnes.

### DIFF
--- a/PKGBUILD/gamescope/0002-fix-initializing-drm-formats.patch
+++ b/PKGBUILD/gamescope/0002-fix-initializing-drm-formats.patch
@@ -1,0 +1,49 @@
+From fa0832f616a1060a3311f9b41368590169ba4872 Mon Sep 17 00:00:00 2001
+From: nullprop <git@nullprop.sh>
+Date: Wed, 20 Nov 2024 18:15:30 +0200
+Subject: [PATCH] rendervulkan: Fix initializing drm formats
+
+Gather the supported DRM formats even if backend doesn't use modifiers.
+---
+ src/rendervulkan.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/rendervulkan.cpp b/src/rendervulkan.cpp
+index 54d7608dd2..d566bbd123 100644
+--- a/src/rendervulkan.cpp
++++ b/src/rendervulkan.cpp
+@@ -2059,7 +2059,7 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
+ 		assert( drmFormat == pDMA->format );
+ 	}
+ 
+-	if ( GetBackend()->UsesModifiers() && g_device.supportsModifiers() && pDMA && pDMA->modifier != DRM_FORMAT_MOD_INVALID )
++	if ( g_device.supportsModifiers() && pDMA && pDMA->modifier != DRM_FORMAT_MOD_INVALID )
+ 	{
+ 		VkExternalImageFormatProperties externalImageProperties = {
+ 			.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES,
+@@ -2781,14 +2781,14 @@ bool vulkan_init_format(VkFormat format, uint32_t drmFormat)
+ 			uint64_t modifier = modifierProps[j].drmFormatModifier;
+ 
+ 			if ( !is_image_format_modifier_supported( format, drmFormat, modifier ) )
+-			continue;
++				continue;
+ 
+ 			if ( ( modifierProps[j].drmFormatModifierTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT ) == 0 )
+ 			{
+ 				continue;
+ 			}
+ 
+-			if ( !gamescope::Algorithm::Contains( GetBackend()->GetSupportedModifiers( drmFormat ), modifier ) )
++			if ( GetBackend()->UsesModifiers() && !gamescope::Algorithm::Contains( GetBackend()->GetSupportedModifiers( drmFormat ), modifier ) )
+ 				continue;
+ 
+ 			wlr_drm_format_set_add( &sampledDRMFormats, drmFormat, modifier );
+@@ -2799,7 +2799,7 @@ bool vulkan_init_format(VkFormat format, uint32_t drmFormat)
+ 	}
+ 	else
+ 	{
+-		if ( !GetBackend()->SupportsFormat( drmFormat ) )
++		if ( GetBackend()->UsesModifiers() && !GetBackend()->SupportsFormat( drmFormat ) )
+ 			return false;
+ 
+ 		wlr_drm_format_set_add( &sampledDRMFormats, drmFormat, DRM_FORMAT_MOD_INVALID );

--- a/PKGBUILD/gamescope/PKGBUILD
+++ b/PKGBUILD/gamescope/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=gamescope
 _srctag=3.16.1
 pkgver=${_srctag//-/.}.SteamFork
-pkgrel=1
+pkgrel=2
 pkgdesc="gaming shell based on Xwayland, powered by Vulkan and DRM"
 arch=(x86_64)
 url="https://github.com/ValveSoftware/gamescope"
@@ -26,6 +26,7 @@ source=("gamescope-session"
         #       revision when bumping the version here such that the build is reproducible.
         "git+https://github.com/nothings/stb.git#commit=af1a5bc352164740c1cc1354942b1c6b72eacb8a"
 	0001-revert-299bc34.patch
+	0002-fix-initializing-drm-formats.patch
 	)
 sha256sums=('cc7f4950bdec292ea6754de0e878c12d08010a6d181a79420619ec814dd2a435'
             'fe515fce8f151a6c03a89e043044bfddf8cd6ee89027d2cfbcf6f6706c78ca76'
@@ -41,6 +42,7 @@ sha256sums=('cc7f4950bdec292ea6754de0e878c12d08010a6d181a79420619ec814dd2a435'
             'SKIP'
             'SKIP'
 	    'a550ef98fd55e142d2bca9f9fe893172bb9140edfc6df232698324c9d5e4625c' # 0001-revert-299bc34.patch
+	    '31d86f1ee58288d3fe7477dd0dfd23be89b1568b8e893d39ce30642785991d7a' # 0002-fix-initializing-drm-formats.patch
             )
 
 install=gamescope.install


### PR DESCRIPTION
Upstream: https://github.com/ValveSoftware/gamescope/pull/1548