### PR TITLE
Update default kscreen configs for Flip DS

### DIFF
--- a/PKGBUILD/steamfork-customizations/PKGBUILD
+++ b/PKGBUILD/steamfork-customizations/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Fewtarius
 
 pkgname=steamfork-customizations
-pkgver=2024.12.23
+pkgver=2025.01.14
 pkgrel=1
 pkgdesc='SteamFork customizations provider.'
 arch=('any')

--- a/PKGBUILD/steamfork-customizations/src/etc/skel/.local/share/kscreen/b3ec830d411bb3758ece303ff4c10a11
+++ b/PKGBUILD/steamfork-customizations/src/etc/skel/.local/share/kscreen/b3ec830d411bb3758ece303ff4c10a11
@@ -1,0 +1,52 @@
+[
+    {
+        "enabled": true,
+        "id": "ecaa73bfdd9c9dbf1690d4bd0187b081",
+        "metadata": {
+            "fullname": "xrandr-AYANEOFHD-539169026",
+            "name": "eDP"
+        },
+        "mode": {
+            "refresh": 120.02743530273438,
+            "size": {
+                "height": 1920,
+                "width": 1080
+            }
+        },
+        "overscan": 0,
+        "pos": {
+            "x": 0,
+            "y": 0
+        },
+        "priority": 1,
+        "rgbrange": 0,
+        "rotation": 2,
+        "scale": 1,
+        "vrrpolicy": 2
+    },
+    {
+        "enabled": true,
+        "id": "7416f805407bf1da569f33f5d0b1b68d",
+        "metadata": {
+            "fullname": "xrandr-AYANEOQHD-539168806",
+            "name": "eDP-1"
+        },
+        "mode": {
+            "refresh": 60.003170013427734,
+            "size": {
+                "height": 960,
+                "width": 640
+            }
+        },
+        "overscan": 0,
+        "pos": {
+            "x": 480,
+            "y": 1080
+        },
+        "priority": 2,
+        "rgbrange": 0,
+        "rotation": 2,
+        "scale": 1,
+        "vrrpolicy": 2
+    }
+]

--- a/PKGBUILD/steamfork-customizations/src/etc/skel/.local/share/kscreen/control/configs/b3ec830d411bb3758ece303ff4c10a11
+++ b/PKGBUILD/steamfork-customizations/src/etc/skel/.local/share/kscreen/control/configs/b3ec830d411bb3758ece303ff4c10a11
@@ -1,0 +1,18 @@
+{
+    "outputs": [
+        {
+            "id": "ecaa73bfdd9c9dbf1690d4bd0187b081",
+            "metadata": {
+                "name": "eDP"
+            },
+            "retention": 1
+        },
+        {
+            "id": "7416f805407bf1da569f33f5d0b1b68d",
+            "metadata": {
+                "name": "eDP-1"
+            },
+            "retention": 1
+        }
+    ]
+}

--- a/PKGBUILD/steamfork-customizations/src/etc/skel/.local/share/kscreen/outputs/ecaa73bfdd9c9dbf1690d4bd0187b081
+++ b/PKGBUILD/steamfork-customizations/src/etc/skel/.local/share/kscreen/outputs/ecaa73bfdd9c9dbf1690d4bd0187b081
@@ -1,0 +1,19 @@
+{
+    "id": "cfaac615846132a6d01cbe02ea6286ac",
+    "metadata": {
+        "fullname": "xrandr-AYANEOFHD-539169026",
+        "name": "eDP"
+    },
+    "mode": {
+        "refresh": 120.02743530273438,
+        "size": {
+            "height": 1920,
+            "width": 1080
+        }
+    },
+    "overscan": 0,
+    "rgbrange": 0,
+    "rotation": 2,
+    "scale": 1,
+    "vrrpolicy": 2
+}


### PR DESCRIPTION
Two EDIDs have been found for Flip DS top display.  These kscreen configs should support both.