### PR TITLE
Fix broken legacy-gamescope for newer AMD GPUs

### DIFF
--- a/PKGBUILD/gamescope/PKGBUILD
+++ b/PKGBUILD/gamescope/PKGBUILD
@@ -28,7 +28,7 @@ source=("gamescope-session"
 	0001-revert-299bc34.patch
 	0002-fix-initializing-drm-formats.patch
 	)
-sha256sums=('cc7f4950bdec292ea6754de0e878c12d08010a6d181a79420619ec814dd2a435'
+sha256sums=('214d7b6b37b3e9570d3991c888d4c3256fb17084e51d630c4bef1c0fd359a8f2'
             'fe515fce8f151a6c03a89e043044bfddf8cd6ee89027d2cfbcf6f6706c78ca76'
             'e37ba6107f3a84cf47c2799b537a88583e6cb8951167a9c6a48fa1d85996206b'
             '8e31e370bc644c470483aec4d4b86cd22e7bede48af70a330b1d912500831fc2'

--- a/PKGBUILD/gamescope/gamescope-session
+++ b/PKGBUILD/gamescope/gamescope-session
@@ -344,7 +344,7 @@ GAMESCOPE_DISPLAY=$(get_active_display)
 ### Tests to determine how to start Gamescope.
 HAS_INTEL=$(lspci -nn | grep -iE 'VGA compat.*Intel' | tr ' ' $'\n' | tr -d '][' | grep 8086)
 HAS_AMD=$(lspci -nn | grep -iE 'VGA compat.*AMD' | tr ' ' $'\n' | tr -d '][' | grep 1002)
-HAS_LEGACY=$(lspci -nn | grep -iE 'VGA compat.*(Ellesmere|Lexa|Baffin|Polaris|RX)' | tr ' ' $'\n' | tr -d '][' | grep 1002)
+HAS_LEGACY=$(lspci -nn | grep -iE 'VGA compat.*(Ellesmere|Lexa|Baffin|Polaris)' | tr ' ' $'\n' | tr -d '][' | grep 1002)
 
 if [ -n "${HAS_INTEL}" ] && \
    [ -z "${HAS_AMD}" ]


### PR DESCRIPTION
This fixes the legacy matcher for newer AMD cards that don't need legacy gamescope.