### PR TITLE
lgo: add device quirk

### DIFF
--- a/PKGBUILD/steamfork-device-support/src/usr/lib/hwsupport/devicequirks/LENOVO-83E1/hardware_quirks.sh
+++ b/PKGBUILD/steamfork-device-support/src/usr/lib/hwsupport/devicequirks/LENOVO-83E1/hardware_quirks.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Generated quirk for `LENOVO-83E1`
+# Save to: `/etc/lib/hwsupport/devicequirks/LENOVO-83E1/hardware_quirks.sh`
+# Optional: Submit to the SteamFork project for official support.
+###################################################################
+export GAMESCOPE_RES=" -w 1280 -h 800"
+export X11_ROTATION="left"
+###################################################################


### PR DESCRIPTION
Gamescope is by default correctly oriented, however desktop is not.

For some reason I can't get the desktop to pick this up, but when running `/etc/X11/Xsession.d/999rotate-screen` manually it does work. PRing this because it's the right value, I can look into it at later point when I am more familiar with steam fork.

Also setting Gamescope resolution to half the native resolution.
