### PR TITLE
Issues with Horipad for Steam

### DIFF
--- a/PKGBUILD/steamfork-customizations/src/etc/udev/rules.d/50-horipad-steam-controller.rules
+++ b/PKGBUILD/steamfork-customizations/src/etc/udev/rules.d/50-horipad-steam-controller.rules
@@ -1,0 +1,7 @@
+# Wireless HORIPAD STEAM; Bluetooth
+KERNEL=="hidraw*", KERNELS=="*0F0D:0196*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="0196", MODE="0660", TAG+="uaccess"
+
+# Wired HORIPAD STEAM; USB
+KERNEL=="hidraw*", KERNELS=="*0F0D:01AB*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="01ab", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
The issues section is closed, but I wanted to start a tracking issue to try and sort out the issue I'm having with the Horipad for steam on steamfork, so I guess it will take the for of a PR, hopefully with a working solution eventually.

I had a different set of issues on Chimera os (Special buttons and cap sticks not working) (https://github.com/ChimeraOS/chimeraos/issues/1050) which are reportedly fixed by the following udev rules. 

I would note that the Horipad mostly just worked in steamfork: all the buttons worked, the cap sticks worked, without any special udev rules added. 

I am having an issue with Gyro though: 

The calibration screen looks pretty much fine, but when used with Gyro to mouse or As mouse, I just get completely unusable, glitchy input on both half-life and half-life 2.

Here is a video of the issue:

https://www.youtube.com/watch?v=efiZ2LrUV34

I tried applying the attached udev rules to ` /etc/udev/rules.d/50-horipad-steam-controller.rules` and running

```
sudo udevadm control -R
sudo udevadm trigger
```

But the symptoms persist. 

Other probably not relevant details: Japanese market controller. Maybe the US version is different?

If we don't want to land this, can we keep it open for a while to track the issue? 