### PR TITLE
The key is expiring from cache too quickly causing the build to fail,…

### DIFF
--- a/scripts/build_all_packages
+++ b/scripts/build_all_packages
@@ -5,7 +5,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAKEFILE_PATH="${SCRIPT_DIR}/../Makefile"
 eval $(make -s -f "${MAKEFILE_PATH}" env)
 
-# Path to the packages list
+# Refresh the GPG key periodically
+refresh_gpg_key_periodically() {
+    while true; do
+        gpg --batch --yes --pinentry-mode loopback --list-keys > /dev/null
+        sleep 1800  # Refresh every 30 minutes
+    done
+}
+
+# Start the GPG key refresh in the background
+refresh_gpg_key_periodically &
+
 PACKAGES_LIST="${SCRIPT_DIR}/../metadata/packages.list"
 
 # Read the packages list and build each package with dependencies


### PR DESCRIPTION
… so we should refresh it every 30 minutes in the background while we build.