### PR TITLE
Update F1 Pro orientation quirk patch

### DIFF
--- a/PKGBUILD/linux/0001-drm-panel-orientation-quirks.patch
+++ b/PKGBUILD/linux/0001-drm-panel-orientation-quirks.patch
@@ -140,10 +140,10 @@ index 88aa57c15..d004d7291 100644
  		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONE XPLAYER"),
  		},
  		.driver_data = (void *)&lcd1200x1920_leftside_up,
-+	}, {	/* OneXPlayer OneXFly F1 Pro */
++	}, {	/* OneXPlayer OneXFly F1 series */
 +		.matches = {
 +		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "ONE-NETBOOK"),
-+		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER F1Pro"),
++		  DMI_MATCH(DMI_PRODUCT_NAME, "ONEXPLAYER F1"),
 +		},
 +		.driver_data = (void *)&lcd1080x1920_leftside_up,
  	}, {	/* OrangePi Neo */

--- a/PKGBUILD/linux/PKGBUILD
+++ b/PKGBUILD/linux/PKGBUILD
@@ -7,7 +7,7 @@
 
 pkgbase=linux
 pkgver=6.13.7
-pkgrel=3
+pkgrel=4
 pkgdesc="Linux Stable"
 arch=(x86_64)
 url="https://kernel.org/"
@@ -81,7 +81,7 @@ validpgpkeys=(
 )
 sha256sums=('SKIP'
   'cf7eb7732cfb8707ba78994a68949cee0e925e11c14d9cbea0dc7484eab17ec5' # config
-  'ea564002dbe5ad62a4efce1a6ff8ac5f19ef604e21783c9a9af78f912629bd99' # 0001-drm-panel-orientation-quirks.patch
+  '8ea46d255adc150d9545940c59d3f83203127eb41a6595664bc906f101c8e7e9' # 0001-drm-panel-orientation-quirks.patch
   '71d093c5c95d7bd594dd8dcd804eabe2f6b95398c519ded42b7d8994f384e4d8' # 0002-drm-amdgpu-always-allocate-cleared-VRAM-for-GEM-allo.patch
   '02f5eaede065b7d68ccf469c9f54eab3ce3f0d852624a3430d83bcd6e2bd7dbb' # 0006-Ayaneo-geek-headset-patch.patch
   '3805f3b8b39d9d49586fb5d2a445a9ee54cf00cd1cdedd226e727420196cc568' # 0007-ayaneo-2-headphone-fix.patch


### PR DESCRIPTION
Should now apply to all OneXPlayer F1 handhelds with 1080p panels